### PR TITLE
compatibility changes

### DIFF
--- a/MasterPassword/Java/masterpassword-algorithm/src/main/java/com/lyndir/masterpassword/MPIdenticon.java
+++ b/MasterPassword/Java/masterpassword-algorithm/src/main/java/com/lyndir/masterpassword/MPIdenticon.java
@@ -15,13 +15,14 @@ import java.util.Map;
 
 /**
  * @author lhunath, 15-03-29
+ * @author deekay, 15-04-30
  */
 public class MPIdenticon {
 
     @SuppressWarnings("UnusedDeclaration")
     private static final Logger logger = Logger.get( MPIdenticon.class );
 
-    private static final Charset charset = StandardCharsets.UTF_8;
+    private static final Charset charset = Charset.forName("UTF-8");
     private static final Color[] colors  = new Color[]{
             Color.RED, Color.GREEN, Color.YELLOW, Color.BLUE, Color.MAGENTA, Color.CYAN, Color.MONO };
     private static final char[] leftArm   = new char[]{ '╔', '╚', '╰', '═' };
@@ -70,37 +71,14 @@ public class MPIdenticon {
         return color;
     }
 
-    public enum BackgroundMode {
-        DARK, LIGHT
-    }
-
 
     public enum Color {
-        RED( "#dc322f", "#dc322f" ),
-        GREEN( "#859900", "#859900" ),
-        YELLOW( "#b58900", "#b58900" ),
-        BLUE( "#268bd2", "#268bd2" ),
-        MAGENTA( "#d33682", "#d33682" ),
-        CYAN( "#2aa198", "#2aa198" ),
-        MONO( "#93a1a1", "#586e75" );
-
-        private final String rgbDark;
-        private final String rgbLight;
-
-        Color(final String rgbDark, final String rgbLight) {
-            this.rgbDark = rgbDark;
-            this.rgbLight = rgbLight;
-        }
-
-        public java.awt.Color getAWTColor(BackgroundMode backgroundMode) {
-            switch (backgroundMode) {
-                case DARK:
-                    return new java.awt.Color( Integer.decode( rgbDark ) );
-                case LIGHT:
-                    return new java.awt.Color( Integer.decode( rgbLight ) );
-            }
-
-            throw new UnsupportedOperationException( "Unsupported background mode: " + backgroundMode );
-        }
+        RED,
+        GREEN,
+        YELLOW,
+        BLUE,
+        MAGENTA,
+        CYAN,
+        MONO
     }
 }

--- a/MasterPassword/Java/masterpassword-gui/pom.xml
+++ b/MasterPassword/Java/masterpassword-gui/pom.xml
@@ -142,6 +142,17 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+		
+		<!-- 
+			stubs for com.apple.eawt to be able to build under windows and linux 
+			http://ymasory.github.io/OrangeExtensions/
+		-->
+		<dependency>
+			<groupId>com.yuvimasory</groupId>
+			<artifactId>orange-extensions</artifactId>
+			<version>1.3.0</version>
+			<scope>provided</scope>
+		</dependency>
 
     </dependencies>
 

--- a/MasterPassword/Java/masterpassword-gui/src/main/java/com/lyndir/masterpassword/gui/UnlockFrame.java
+++ b/MasterPassword/Java/masterpassword-gui/src/main/java/com/lyndir/masterpassword/gui/UnlockFrame.java
@@ -4,6 +4,7 @@ import static com.lyndir.lhunath.opal.system.util.ObjectUtils.*;
 
 import com.lyndir.masterpassword.MPIdenticon;
 import com.lyndir.masterpassword.gui.util.Components;
+import com.lyndir.masterpassword.gui.util.MPIdenticonColorUtil;
 import com.lyndir.masterpassword.model.IncorrectMasterPasswordException;
 import java.awt.*;
 import java.awt.event.*;
@@ -147,8 +148,10 @@ public class UnlockFrame extends JFrame {
             identiconLabel.setText( " " );
         else {
             MPIdenticon identicon = new MPIdenticon( fullName, masterPassword );
-            identiconLabel.setText( identicon.getText() );
-            identiconLabel.setForeground( identicon.getColor().getAWTColor( MPIdenticon.BackgroundMode.DARK ) );
+            identiconLabel.setText(identicon.getText());
+            Color color = MPIdenticonColorUtil.fromMPIdenticonColor(
+                    identicon.getColor()).getAWTColor(MPIdenticonColorUtil.BackgroundMode.DARK);
+            identiconLabel.setForeground( color );
         }
 
         signInButton.setEnabled( enabled );

--- a/MasterPassword/Java/masterpassword-gui/src/main/java/com/lyndir/masterpassword/gui/util/MPIdenticonColorUtil.java
+++ b/MasterPassword/Java/masterpassword-gui/src/main/java/com/lyndir/masterpassword/gui/util/MPIdenticonColorUtil.java
@@ -1,0 +1,56 @@
+package com.lyndir.masterpassword.gui.util;
+
+import com.lyndir.masterpassword.MPIdenticon.Color;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author deekay, 2015-04-30
+ */
+public class MPIdenticonColorUtil {
+
+    private static Map<Color, BackgroundModeAwareColorCode> colors;
+
+    static {
+        colors = new HashMap<>();
+        colors.put(Color.RED, new BackgroundModeAwareColorCode("#dc322f", "#dc322f"));
+        colors.put(Color.GREEN, new BackgroundModeAwareColorCode("#859900", "#859900"));
+        colors.put(Color.YELLOW, new BackgroundModeAwareColorCode("#b58900", "#b58900"));
+        colors.put(Color.BLUE, new BackgroundModeAwareColorCode("#268bd2", "#268bd2"));
+        colors.put(Color.MAGENTA, new BackgroundModeAwareColorCode("#d33682", "#d33682"));
+        colors.put(Color.CYAN, new BackgroundModeAwareColorCode("#2aa198", "#2aa198"));
+        colors.put(Color.MONO, new BackgroundModeAwareColorCode("#93a1a1", "#586e75"));
+    }
+
+    public static BackgroundModeAwareColorCode fromMPIdenticonColor(Color color) {
+        return colors.get(color);
+    }
+
+    public enum BackgroundMode {
+        DARK, LIGHT
+    }
+
+    public static class BackgroundModeAwareColorCode {
+        private final String rgbDark;
+        private final String rgbLight;
+
+        BackgroundModeAwareColorCode(final String rgbDark, final String rgbLight) {
+            this.rgbDark = rgbDark;
+            this.rgbLight = rgbLight;
+        }
+
+        public java.awt.Color getAWTColor(BackgroundMode backgroundMode) {
+            switch (backgroundMode) {
+                case DARK:
+                    return new java.awt.Color(Integer.decode(rgbDark));
+                case LIGHT:
+                    return new java.awt.Color(Integer.decode(rgbLight));
+            }
+
+            throw new UnsupportedOperationException("Unsupported background mode: " + backgroundMode);
+        }
+    }
+
+
+}


### PR DESCRIPTION
To be able to build under Windows or Linux I included stubs for com.apple.eawt classes that are not available in the JDK on other systems.
Also I changed the MPIdenticon to not include awt classes. (it is in the algorithm project and should therefore not care about graphics)
Last change is for adding compatibility for Android versions below KitKat to MPIdenticon. StandardCharsets is unfortunately only available on API Level 19 and higher in the Android SDK.