### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Gittip](http://img.shields.io/gittip/lhunath.png)](https://www.gittip.com/lhunath/)
 [![Travis CI](http://img.shields.io/travis-ci/Lyndir/MasterPassword.png)](https://travis-ci.org/Lyndir/MasterPassword)
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=5657a29028898101003ae8f8&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/5657a29028898101003ae8f8/build/latest)
 
 # Master Password
 


### PR DESCRIPTION
We really liked Master Password and wanted to offer you a free continuous integration system [(buddybuild)](buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/5657a29028898101003ae8f8/build/latest) are the builds we've completed for Master Password so far.

![screen shot 2015-11-26 at 5 20 20 pm](https://cloud.githubusercontent.com/assets/13876667/11432382/12cc11a0-9462-11e5-8851-3510fada3836.png)

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.