### PR TITLE
Update algorithm to correct counter.

### DIFF
--- a/Site/2013-05/algorithm.html
+++ b/Site/2013-05/algorithm.html
@@ -81,7 +81,7 @@
                         This is the secret for the master key generation.</li>
                         <li><strong>The site name</strong> (eg. <em>apple.com</em>):<br />
                         The user chooses a name for each site.  The bare domain name is an ideal choice.</li>
-                        <li><strong>The site's password counter</strong> (default: <em>0</em>):<br />
+                        <li><strong>The site's password counter</strong> (default: <em>1</em>):<br />
                         This is an integer that can be incremented when the user needs a new password for the site.</li>
                         <li><strong>The site's password type</strong> (default: <em>Long Password</em>):<br />
                         This type determines the format of the output password.  It can be changed if the site's password policy does not accept passwords of this format.</li>


### PR DESCRIPTION
The counter in algorithm.html says the default is 0, however all the official (and non official) apps start at 1. This caused a few problems for me when using other applications based on the master password format. The freepass password manager seems to have based its algorithm off this page and used 0, which means all passwords from that password manager can't be generated by master password applications because the counter starts at 1.