### PR TITLE
fixed wording on set password dialog

### DIFF
--- a/MasterPassword/ObjC/Mac/MPPasswordWindowController.xib
+++ b/MasterPassword/ObjC/Mac/MPPasswordWindowController.xib
@@ -78,7 +78,7 @@
                                     <size key="offset" width="0.0" height="1"/>
                                     <color key="color" name="controlLightHighlightColor" catalog="System" colorSpace="catalog"/>
                                 </shadow>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="No password set.  Click &quot;Change Password&quot; on the bottom to set one." id="eDQ-iz-97a">
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="No password set.  Click &quot;Set Password&quot; on the bottom to set one." id="eDQ-iz-97a">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
The wording says "Click 'Change Password' ...", but the button says "Set Password", not "Change Password".