### PR TITLE
Corrected conversion exception (from long to UnsignedInteger) on linux oracle and open jdk.

### DIFF
--- a/MasterPassword/Java/masterpassword-gui/src/main/java/com/lyndir/masterpassword/gui/PasswordFrame.java
+++ b/MasterPassword/Java/masterpassword-gui/src/main/java/com/lyndir/masterpassword/gui/PasswordFrame.java
@@ -119,7 +119,7 @@ public class PasswordFrame extends JFrame implements DocumentListener {
                                                         siteVersionField = Components.comboBox( MasterKey.Version.values() ), //
                                                         Components.stud(),                                                    //
                                                         siteCounterField = Components.spinner(
-                                                                new SpinnerNumberModel( 1L, 1L, UnsignedInteger.MAX_VALUE, 1L ) ) );
+                                                                new SpinnerNumberModel( UnsignedInteger.ONE, UnsignedInteger.ONE, UnsignedInteger.MAX_VALUE, UnsignedInteger.ONE ) ) );
         sitePanel.add( siteSettings );
         siteTypeField.setFont( Res.valueFont().deriveFont( 12f ) );
         siteTypeField.setSelectedItem( MPSiteType.GeneratedLong );


### PR DESCRIPTION
Using longs in some of the parameters of the SpinnerNumberModel caused an exception in the login on my machine.