### PR TITLE
Added the option "-selection clip" to the xclip command. This fixes

### DIFF
--- a/MasterPassword/C/mpw.bashrc
+++ b/MasterPassword/C/mpw.bashrc
@@ -5,7 +5,7 @@ mpw() {
         if hash pbcopy 2>/dev/null; then
             pbcopy
         elif hash xclip 2>/dev/null; then
-            xclip
+            xclip -selection clip
         else
             cat; echo 2>/dev/null
             return


### PR DESCRIPTION
Fixes the bug that the automatic copying to the clipboard accessible with
ctrl-V in applications like in e.g Firefox is not working in Open-SUSE
41.1 and i suspect in other Linux distributions as well.

I do not know if the previous choice of not having option specified was well grounded and the 
missing compatibility with linux unavoidable.  