### PR TITLE
[WIP]: Enable/disable keyboard input.

### DIFF
--- a/MasterPassword/C/mpw-cli.c
+++ b/MasterPassword/C/mpw-cli.c
@@ -212,6 +212,9 @@ int main(int argc, char *const argv[]) {
     // Summarize operation.
     fprintf( stderr, "%s's password for %s:\n[ %s ]: ", fullName, siteName, mpw_identicon( fullName, masterPassword ) );
 
+	// Disable keyboard input.
+	mpw_toggle_term_echo();
+
     // Output the password.
     const uint8_t *masterKey = mpw_masterKeyForUser(
             fullName, masterPassword, algorithmVersion );
@@ -226,5 +229,8 @@ int main(int argc, char *const argv[]) {
         ftl( "Couldn't derive site password." );
 
     fprintf( stdout, "%s\n", sitePassword );
+
+	// Enable keyboard input.
+	mpw_toggle_term_echo();
     return 0;
 }

--- a/MasterPassword/C/mpw-util.c
+++ b/MasterPassword/C/mpw-util.c
@@ -147,7 +147,6 @@ static int putvar(int c) {
 
 
 void mpw_toggle_term_echo () {
-   static sigset_t sigOld;
    static struct termios termOld;
    static FILE *fp = NULL;
 
@@ -155,14 +154,9 @@ void mpw_toggle_term_echo () {
        if ((fp = fopen( ctermid(NULL), "r+")) == NULL)
             return;
 
-        sigset_t sig;
-        struct  termios term;
-
         setbuf( fp, NULL);
-        sigemptyset( &sig );
-        sigaddset( &sig, SIGINT); /* block SIGINT */
-        sigaddset( &sig, SIGTSTP); /* block SIGTSTP */
-        sigprocmask( SIG_BLOCK, &sig, &sigOld);
+
+        struct  termios term;
 
         tcgetattr( fileno(fp), &term);
         termOld = term; /*save attr.*/
@@ -172,7 +166,6 @@ void mpw_toggle_term_echo () {
 
     } else {
         tcsetattr( fileno(fp), TCSAFLUSH, &termOld);
-        sigprocmask( SIG_SETMASK, &sigOld, NULL);
         fclose(fp);
         fp = NULL;
     }

--- a/MasterPassword/C/mpw-util.h
+++ b/MasterPassword/C/mpw-util.h
@@ -8,6 +8,8 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <signal.h>
+#include <termio.h>
 
 //// Logging.
 
@@ -77,6 +79,9 @@ void mpw_free(
 /** Free a string after zero'ing its contents. */
 void mpw_freeString(
         const char *string);
+
+/** Enable/Disable keyboard input **/
+void mpw_toggle_term_echo ();
 
 //// Cryptographic functions.
 

--- a/MasterPassword/C/mpw-util.h
+++ b/MasterPassword/C/mpw-util.h
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <signal.h>
-#include <termio.h>
+#include <termios.h>
 
 //// Logging.
 

--- a/MasterPassword/C/mpw-util.h
+++ b/MasterPassword/C/mpw-util.h
@@ -8,7 +8,6 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include <signal.h>
 #include <termios.h>
 
 //// Logging.


### PR DESCRIPTION
At the end of the program when the password is calculated, a delay occurs.
At that time if the user presses a key, the key is going to be placed in the result field of the password.
Solution: Temporarily disable the keyboard input.
Note: It is POSIX compliant. I do not know if it works out of *nix.