### PR TITLE
Fix: segfault when getenv return NULL.

### DIFF
--- a/MasterPassword/C/mpw-cli.c
+++ b/MasterPassword/C/mpw-cli.c
@@ -96,7 +96,7 @@ static char *getline_prompt(const char *prompt) {
 int main(int argc, char *const argv[]) {
 
     // Read the environment.
-    char *fullName = strdup( getenv( MP_env_fullname ) );
+    char *fullName = NULL;
     const char *masterPassword = NULL;
     const char *siteName = NULL;
     MPSiteType siteType = MPSiteTypeGeneratedLong;
@@ -169,8 +169,14 @@ int main(int argc, char *const argv[]) {
         siteName = strdup( argv[optind] );
 
     // Convert and validate input.
+
+    const char * const env = getenv( MP_env_fullname );
+    if (!fullName && env)
+        fullName = strdup (env);
+
     if (!fullName && !(fullName = getline_prompt( "Your full name:" )))
         ftl( "Missing full name.\n" );
+
     if (!siteName && !(siteName = getline_prompt( "Site name:" )))
         ftl( "Missing site name.\n" );
     if (siteCounterString)


### PR DESCRIPTION
When `getenv` return `NULL` and use `strdup`: segfault.