### PR TITLE
Fix getline: check for newline.

### DIFF
--- a/MasterPassword/C/mpw-cli.c
+++ b/MasterPassword/C/mpw-cli.c
@@ -85,7 +85,7 @@ static char *getline_prompt(const char *prompt) {
     ssize_t lineSize;
     fprintf( stderr, "%s", prompt );
     fprintf( stderr, " " );
-    if ((lineSize = getline( &buf, &bufSize, stdin )) < 0) {
+    if ((lineSize = getline( &buf, &bufSize, stdin )) < 0 || lineSize == 1) {
         free( buf );
         return NULL;
     }


### PR DESCRIPTION
When you press only the `Enter key`, the line break is the only one in the buffer: `\n`
This commit indicates it as an error. Return NULL.
