### PR TITLE
Add a system property to keep the Java gui open.

### DIFF
--- a/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/view/PasswordFrame.java
+++ b/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/view/PasswordFrame.java
@@ -88,7 +88,10 @@ public class PasswordFrame extends JFrame implements DocumentListener {
                                 passwordField.setText( null );
                                 siteNameField.setText( null );
 
-                                dispatchEvent( new WindowEvent( PasswordFrame.this, WindowEvent.WINDOW_CLOSING ) );
+                                String p = System.getProperty("mpw.keep-gui");
+                                if (p == null || p != "1") {
+                                    dispatchEvent( new WindowEvent( PasswordFrame.this, WindowEvent.WINDOW_CLOSING ) );
+                                }
                             }
                         } );
                     }


### PR DESCRIPTION
The automatic closing of the window leads to program termination which
leads to some problems on *nix systems that run Xorg.
Per default anything copied to the clipboard by an application ceases to
be if the app is closed. Therefore the password copy feature is useless
in that case.

A system property `mpw.keep-gui` is introduced which will prevent the
automatic closing of the window if set to `1`.
