### PR TITLE
build scripts: OpenSSL 1.1.0c compatibility

### DIFF
--- a/MasterPassword/C/build
+++ b/MasterPassword/C/build
@@ -51,7 +51,7 @@ fi
 ### DEPENDENCIES
 
 digest() {
-    openssl sha -sha256 -binary < "$1" | od -t x1 -An -v | tr -d '[:space:]'
+    openssl sha256 -binary < "$1" | od -t x1 -An -v | tr -d '[:space:]'
 }
 fetch() {
     if hash wget 2>/dev/null; then

--- a/MasterPassword/C/distribute
+++ b/MasterPassword/C/distribute
@@ -12,7 +12,7 @@ mpwArchive=mpw-$commit.tar.gz
 read -n1 -p "Will prepare and release $mpwArchive.  Press a key to continue or ^C to abort."
 
 git ls-files -z . | xargs -0 tar -Lcvzf "$mpwArchive"
-echo "$mpwArchive ready, SHA256: $(openssl sha -sha256 < "$mpwArchive")"
+echo "$mpwArchive ready, SHA256: $(openssl sha256 < "$mpwArchive")"
 
 cd ../../Site/current
 ln -sf "../../MasterPassword/C/$mpwArchive"


### PR DESCRIPTION
While compiling CLI version on Debian Testing with OpenSSL 1.1.0c I'm getting errors such as:

> Verifying package: libscrypt-b12b554.tar.gz, against digest: c726daec68a345e420896f005394a948dc5a6924713ed94b684c856d4c247f0b...Invalid command 'sha'; type "help" for a list.

> Verifying package: ../crypt_blowfish-1.3.tar.gz, against digest: 83fa01fca6996fe8d882b7f8e9ba0305a5664936100b01481ea3c6a8ce8d72fd...Invalid command 'sha'; type "help" for a list.

With "openssl sha256" it works well.

I'm just not sure if it works with lower versions of OpenSSL.