### PR TITLE
Fix #129 No more missing symbols from o in x class

### DIFF
--- a/MasterPassword/C/mpw-algorithm.c
+++ b/MasterPassword/C/mpw-algorithm.c
@@ -11,6 +11,7 @@
 #include "mpw-algorithm_v1.c"
 #include "mpw-algorithm_v2.c"
 #include "mpw-algorithm_v3.c"
+#include "mpw-algorithm_v4.c"
 
 #define MP_N                32768
 #define MP_r                8
@@ -31,6 +32,8 @@ const uint8_t *mpw_masterKeyForUser(const char *fullName, const char *masterPass
             return mpw_masterKeyForUser_v2( fullName, masterPassword );
         case MPAlgorithmVersion3:
             return mpw_masterKeyForUser_v3( fullName, masterPassword );
+        case MPAlgorithmVersion4:
+            return mpw_masterKeyForUser_v4( fullName, masterPassword );
         default:
             ftl( "Unsupported version: %d", algorithmVersion );
             return NULL;
@@ -52,6 +55,8 @@ const char *mpw_passwordForSite(const uint8_t *masterKey, const char *siteName, 
             return mpw_passwordForSite_v2( masterKey, siteName, siteType, siteCounter, siteVariant, siteContext );
         case MPAlgorithmVersion3:
             return mpw_passwordForSite_v3( masterKey, siteName, siteType, siteCounter, siteVariant, siteContext );
+        case MPAlgorithmVersion4:
+            return mpw_passwordForSite_v4( masterKey, siteName, siteType, siteCounter, siteVariant, siteContext );
         default:
             ftl( "Unsupported version: %d", algorithmVersion );
             return NULL;

--- a/MasterPassword/C/mpw-algorithm.h
+++ b/MasterPassword/C/mpw-algorithm.h
@@ -16,10 +16,12 @@ typedef enum(unsigned int, MPAlgorithmVersion) {
             MPAlgorithmVersion1,
     /** V2 miscounted the byte-length of multi-byte user names. */
             MPAlgorithmVersion2,
-    /** V3 is the current version. */
+    /** V3 missing symbols from o in x character class. */
             MPAlgorithmVersion3,
+    /** V4 is the current version. */
+            MPAlgorithmVersion4,
 };
-#define MPAlgorithmVersionCurrent MPAlgorithmVersion3
+#define MPAlgorithmVersionCurrent MPAlgorithmVersion4
 
 /** Derive the master key for a user based on their name and master password.
  * @return A new MP_dkLen-byte allocated buffer or NULL if an allocation error occurred. */

--- a/MasterPassword/C/mpw-algorithm_v4.c
+++ b/MasterPassword/C/mpw-algorithm_v4.c
@@ -1,0 +1,114 @@
+//
+//  mpw-algorithm.c
+//  MasterPassword
+//
+
+
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+
+#include "mpw-types.h"
+#include "mpw-util.h"
+
+// The MP_N have been incremented so passwords generated won't match with the precedent version
+#define MP_N_v4             32769
+#define MP_r                8
+#define MP_p                2
+#define MP_hash             PearlHashSHA256
+
+static const uint8_t *mpw_masterKeyForUser_v4(const char *fullName, const char *masterPassword) {
+
+    const char *mpKeyScope = mpw_scopeForVariant( MPSiteVariantPassword );
+    trc( "algorithm: v%d\n", 3 );
+    trc( "fullName: %s (%zu)\n", fullName, strlen( fullName ) );
+    trc( "masterPassword: %s\n", masterPassword );
+    trc( "key scope: %s\n", mpKeyScope );
+
+    // Calculate the master key salt.
+    // masterKeySalt = mpKeyScope . #fullName . fullName
+    size_t masterKeySaltSize = 0;
+    uint8_t *masterKeySalt = NULL;
+    mpw_push_string( &masterKeySalt, &masterKeySaltSize, mpKeyScope );
+    mpw_push_int( &masterKeySalt, &masterKeySaltSize, htonl( strlen( fullName ) ) );
+    mpw_push_string( &masterKeySalt, &masterKeySaltSize, fullName );
+    if (!masterKeySalt) {
+        ftl( "Could not allocate master key salt: %d\n", errno );
+        return NULL;
+    }
+    trc( "masterKeySalt ID: %s\n", mpw_id_buf( masterKeySalt, masterKeySaltSize ) );
+
+    // Calculate the master key.
+    // masterKey = scrypt( masterPassword, masterKeySalt )
+    const uint8_t *masterKey = mpw_scrypt( MP_dkLen, masterPassword, masterKeySalt, masterKeySaltSize, MP_N_v4, MP_r, MP_p );
+    mpw_free( masterKeySalt, masterKeySaltSize );
+    if (!masterKey) {
+        ftl( "Could not allocate master key: %d\n", errno );
+        return NULL;
+    }
+    trc( "masterKey ID: %s\n", mpw_id_buf( masterKey, MP_dkLen ) );
+
+    return masterKey;
+}
+
+static const char *mpw_passwordForSite_v4(const uint8_t *masterKey, const char *siteName, const MPSiteType siteType, const uint32_t siteCounter,
+        const MPSiteVariant siteVariant, const char *siteContext) {
+
+    const char *siteScope = mpw_scopeForVariant( siteVariant );
+    trc( "algorithm: v%d\n", 4 );
+    trc( "siteName: %s\n", siteName );
+    trc( "siteCounter: %d\n", siteCounter );
+    trc( "siteVariant: %d\n", siteVariant );
+    trc( "siteType: %d\n", siteType );
+    trc( "site scope: %s, context: %s\n", siteScope, siteContext? "<empty>": siteContext );
+    trc( "seed from: hmac-sha256(masterKey, %s | %s | %s | %s | %s | %s)\n",
+            siteScope, mpw_hex_l( htonl( strlen( siteName ) ) ), siteName,
+            mpw_hex_l( htonl( siteCounter ) ),
+            mpw_hex_l( htonl( siteContext? strlen( siteContext ): 0 ) ), siteContext? "(null)": siteContext );
+
+    // Calculate the site seed.
+    // sitePasswordSeed = hmac-sha256( masterKey, siteScope . #siteName . siteName . siteCounter . #siteContext . siteContext )
+    size_t sitePasswordInfoSize = 0;
+    uint8_t *sitePasswordInfo = NULL;
+    mpw_push_string( &sitePasswordInfo, &sitePasswordInfoSize, siteScope );
+    mpw_push_int( &sitePasswordInfo, &sitePasswordInfoSize, htonl( strlen( siteName ) ) );
+    mpw_push_string( &sitePasswordInfo, &sitePasswordInfoSize, siteName );
+    mpw_push_int( &sitePasswordInfo, &sitePasswordInfoSize, htonl( siteCounter ) );
+    if (siteContext) {
+        mpw_push_int( &sitePasswordInfo, &sitePasswordInfoSize, htonl( strlen( siteContext ) ) );
+        mpw_push_string( &sitePasswordInfo, &sitePasswordInfoSize, siteContext );
+    }
+    if (!sitePasswordInfo) {
+        ftl( "Could not allocate site seed info: %d\n", errno );
+        return NULL;
+    }
+    trc( "sitePasswordInfo ID: %s\n", mpw_id_buf( sitePasswordInfo, sitePasswordInfoSize ) );
+
+    const uint8_t *sitePasswordSeed = mpw_hmac_sha256( masterKey, MP_dkLen, sitePasswordInfo, sitePasswordInfoSize );
+    mpw_free( sitePasswordInfo, sitePasswordInfoSize );
+    if (!sitePasswordSeed) {
+        ftl( "Could not allocate site seed: %d\n", errno );
+        return NULL;
+    }
+    trc( "sitePasswordSeed ID: %s\n", mpw_id_buf( sitePasswordSeed, 32 ) );
+
+    // Determine the template.
+    const char *template = mpw_templateForType( siteType, sitePasswordSeed[0] );
+    trc( "type %d, template: %s\n", siteType, template );
+    if (strlen( template ) > 32) {
+        ftl( "Template too long for password seed: %lu", strlen( template ) );
+        mpw_free( sitePasswordSeed, sizeof( sitePasswordSeed ) );
+        return NULL;
+    }
+
+    // Encode the password from the seed using the template.
+    char *const sitePassword = calloc( strlen( template ) + 1, sizeof( char ) );
+    for (size_t c = 0; c < strlen( template ); ++c) {
+        sitePassword[c] = mpw_characterFromClass_v4( template[c], sitePasswordSeed[c + 1] );
+        trc( "class %c, index %u (0x%02X) -> character: %c\n", template[c], sitePasswordSeed[c + 1], sitePasswordSeed[c + 1],
+                sitePassword[c] );
+    }
+    mpw_free( sitePasswordSeed, sizeof( sitePasswordSeed ) );
+
+    return sitePassword;
+}

--- a/MasterPassword/C/mpw-types.c
+++ b/MasterPassword/C/mpw-types.c
@@ -186,8 +186,44 @@ const char *mpw_charactersInClass(char characterClass) {
     }
 }
 
+const char *mpw_charactersInClass_v4(char characterClass) {
+
+    switch (characterClass) {
+        case 'V':
+            return "AEIOU";
+        case 'C':
+            return "BCDFGHJKLMNPQRSTVWXYZ";
+        case 'v':
+            return "aeiou";
+        case 'c':
+            return "bcdfghjklmnpqrstvwxyz";
+        case 'A':
+            return "AEIOUBCDFGHJKLMNPQRSTVWXYZ";
+        case 'a':
+            return "AEIOUaeiouBCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz";
+        case 'n':
+            return "0123456789";
+        case 'o':
+            return "@&%?,=[]_:-+*$#!'^~;()/.";
+        case 'x':
+            return "AEIOUaeiouBCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz0123456789@&%?,=[]_:-+*$#!'^~;()/.";
+        case ' ':
+            return " ";
+        default: {
+            fprintf( stderr, "Unknown character class: %c", characterClass );
+            abort();
+        }
+    }
+}
+
 const char mpw_characterFromClass(char characterClass, uint8_t seedByte) {
 
     const char *classCharacters = mpw_charactersInClass( characterClass );
+    return classCharacters[seedByte % strlen( classCharacters )];
+}
+
+const char mpw_characterFromClass_v4(char characterClass, uint8_t seedByte) {
+
+    const char *classCharacters = mpw_charactersInClass_v4( characterClass );
     return classCharacters[seedByte % strlen( classCharacters )];
 }

--- a/MasterPassword/C/mpw-types.h
+++ b/MasterPassword/C/mpw-types.h
@@ -78,7 +78,7 @@ const MPSiteType mpw_typeWithName(const char *typeName);
  * @return A newly allocated array of internal strings that express the templates to use for the given type.
  *         The amount of elements in the array is stored in count.
  *         If an unsupported type is given, count will be 0 and will return NULL.
-*          The array needs to be free'ed, the strings themselves must not be free'ed or modified.
+ *         The array needs to be free'ed, the strings themselves must not be free'ed or modified.
  */
 const char **mpw_templatesForType(MPSiteType type, size_t *count);
 /**
@@ -91,9 +91,21 @@ const char *mpw_templateForType(MPSiteType type, uint8_t seedByte);
  * @return An internal string that contains all the characters that occur in the given character class.
  */
 const char *mpw_charactersInClass(char characterClass);
+
+/**
+ * @return An internal string that contains all the characters that occur in the given character class.
+ * For the version 4.
+ */
+const char *mpw_charactersInClass_v4(char characterClass);
+
 /**
  * @return A character from given character class that encodes the given byte.
  */
 const char mpw_characterFromClass(char characterClass, uint8_t seedByte);
+
+/**
+ * @return A character from given character class that encodes the given byte. For the version 4.
+ */
+const char mpw_characterFromClass_v4(char characterClass, uint8_t seedByte);
 
 #endif // _MPW_TYPES_H


### PR DESCRIPTION
Because of breaking changes the new version is now v4.
The scrypt parameter MP_N have been changed so new passwords will be different.
I will add tests, modify the other versions (other than C) and change the documentation.