### PR TITLE
Handle openssl 1.0.X using sha and 1.1.0 using sha256. 

### DIFF
--- a/platform-independent/cli-c/build
+++ b/platform-independent/cli-c/build
@@ -56,7 +56,12 @@ fi
 ### DEPENDENCIES
 
 digest() {
-    openssl sha -sha256 -binary < "$1" | od -t x1 -An -v | tr -d '[:space:]'
+    HAS_SHA_256=`openssl help 2>&1 | grep -c sha256`
+    if [ "${HAS_SHA_256}" -gt 0 ]; then
+	openssl sha256 -binary < "$1" | od -t x1 -An -v | tr -d '[:space:]'
+    else
+	openssl sha -sha256 -binary < "$1" | od -t x1 -An -v | tr -d '[:space:]'
+    fi
 }
 fetch() {
     if hash wget 2>/dev/null; then


### PR DESCRIPTION
Tried to re-use the solution in the forum article (http://forum.directadmin.com/showthread.php?t=54346). I have tested it and it now works for me with openssl 1.1.0 and it should work with 1.0.X as well. 

#149 