### PR TITLE
Fixes to the java application for linux/oracle jvm

### DIFF
--- a/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/GUI.java
+++ b/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/GUI.java
@@ -43,7 +43,7 @@ public class GUI implements UnlockFrame.SignInCallback {
     @SuppressWarnings("UnusedDeclaration")
     private static final Logger logger = Logger.get( GUI.class );
 
-    private final UnlockFrame unlockFrame = new UnlockFrame( this );
+    protected final UnlockFrame unlockFrame = new UnlockFrame( this );
     private PasswordFrame passwordFrame;
 
     public static void main(final String... args) {

--- a/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/model/ModelSite.java
+++ b/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/model/ModelSite.java
@@ -65,7 +65,7 @@ public class ModelSite extends Site {
 
     @Override
     public void setSiteCounter(final UnsignedInteger siteCounter) {
-        if (siteCounter.equals( getSiteCounter() )) {
+        if (!siteCounter.equals( getSiteCounter() )) {
             model.setSiteCounter( siteCounter );
             MPUserFileManager.get().save();
         }

--- a/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/platform/mac/AppleGUI.java
+++ b/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/platform/mac/AppleGUI.java
@@ -15,24 +15,29 @@ public class AppleGUI extends GUI {
 
     public AppleGUI() {
 
-        Application application = Application.getApplication();
-        application.addAppEventListener( new AppForegroundListener() {
+        try {
+            Application application = Application.getApplication();
+            application.addAppEventListener(new AppForegroundListener() {
 
-            @Override
-            public void appMovedToBackground(final AppEvent.AppForegroundEvent arg0) {
-            }
+                @Override
+                public void appMovedToBackground(final AppEvent.AppForegroundEvent arg0) {
+                }
 
-            @Override
-            public void appRaisedToForeground(final AppEvent.AppForegroundEvent arg0) {
-                open();
-            }
-        } );
-        application.addAppEventListener( new AppReOpenedListener() {
-            @Override
-            public void appReOpened(final AppEvent.AppReOpenedEvent arg0) {
-                open();
-            }
-        } );
+                @Override
+                public void appRaisedToForeground(final AppEvent.AppForegroundEvent arg0) {
+                    open();
+                }
+            });
+            application.addAppEventListener(new AppReOpenedListener() {
+                @Override
+                public void appReOpened(final AppEvent.AppReOpenedEvent arg0) {
+                    open();
+                }
+            });
+        } catch (Throwable t) {
+            unlockFrame.dispose();
+            throw t;
+        }
     }
 
     @Override

--- a/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/util/UnsignedIntegerModel.java
+++ b/platform-independent/gui-java/src/main/java/com/lyndir/masterpassword/gui/util/UnsignedIntegerModel.java
@@ -27,11 +27,11 @@ public class UnsignedIntegerModel extends SpinnerNumberModel {
 
     public UnsignedIntegerModel(final UnsignedInteger value, final UnsignedInteger minimum, final UnsignedInteger maximum,
                                 final UnsignedInteger stepSize) {
-        super( value, minimum, maximum, stepSize );
+        super( value.doubleValue(), minimum.doubleValue(), maximum.doubleValue(), stepSize.doubleValue() );
     }
 
     @Override
     public UnsignedInteger getNumber() {
-        return (UnsignedInteger) super.getNumber();
+        return UnsignedInteger.valueOf( super.getNumber().longValue() );
     }
 }


### PR DESCRIPTION
The commit messages (with minor corrections):

- On linux, the application fails to to stop gracefully, the problem is that the UnlockFrame is instantiated two times by 'TypeUtils.<GUI>newInstance( "com.lyndir.masterpassword.gui.platform.mac.AppleGUI" ).or( new GUI() ).open()' and the close operation only disposes the second.
    This commit fixes the problem for linux by disposing the unused UnlockFrame created by the AppleGUI failed instantiation. However, according to my tests, even if AppleGUI didn't threw an exception the UnlockFrame would still be created twice (by the 'new GUI()') which I think is not the objective. Maybe the "or" should be changed for a simple if !isPresent() or something like that.

- Fixes to the site counter handling:
      - Using UnsignedInteger directly in the SpinnerNumberModel doesn't work in Oracle 1.8.0_131. I don't know how it worked before (I had tested the previous version of the spinner model) but now it only works with the basic number types (Float, Double, Integer, Long, Short or Byte). I chose Double to avoid having to add casts to Comparable to use the constructor with longs.
      - Added the negation to the if condition on ModelSite to allow changing the site counter of stored sites.