### PR TITLE
Fix bcrypt build

### DIFF
--- a/platform-independent/cli-c/cli/bcrypt.h
+++ b/platform-independent/cli-c/cli/bcrypt.h
@@ -36,6 +36,7 @@
 #include <errno.h>
 #include <pwd.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>


### PR DESCRIPTION
```In file included from cli/mpw-bench.c:34:0:
cli/bcrypt.h:59:40: error: unknown type name ‘uint8_t’
 static int encode_base64(char *, const uint8_t *, size_t);
                                        ^~~~~~~
cli/bcrypt.h:60:26: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
 static int decode_base64(uint8_t *, size_t, const char *);
                          ^~~~~~~
                          u_int8_t
cli/bcrypt.h:66:33: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
 bcrypt_initsalt(int log_rounds, uint8_t *salt, size_t saltbuflen) {
                                 ^~~~~~~
                                 u_int8_t
cli/bcrypt.h:92:40: error: unknown type name ‘uint8_t’
 bcrypt_hashpass(const char *key, const uint8_t *salt, char *encrypted,
                                        ^~~~~~~
cli/bcrypt.h: In function ‘bcrypt_hashpass’:
cli/bcrypt.h:96:5: error: unknown type name ‘uint32_t’; did you mean ‘u_int32_t’?
     uint32_t rounds, i, k;
     ^~~~~~~~
     u_int32_t
cli/bcrypt.h:97:5: error: unknown type name ‘uint16_t’; did you mean ‘u_int16_t’?
     uint16_t j;
     ^~~~~~~~
     u_int16_t
cli/bcrypt.h:99:5: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
     uint8_t salt_len, logr, minor;
     ^~~~~~~
     u_int8_t
cli/bcrypt.h:100:5: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
     uint8_t ciphertext[4 * BCRYPT_WORDS] = "OrpheanBeholderScryDoubt";
     ^~~~~~~
     u_int8_t
cli/bcrypt.h:100:44: error: wide character array initialized from non-wide string
     uint8_t ciphertext[4 * BCRYPT_WORDS] = "OrpheanBeholderScryDoubt";
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
cli/bcrypt.h:101:5: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
     uint8_t csalt[BCRYPT_MAXSALT];
     ^~~~~~~
     u_int8_t
cli/bcrypt.h:102:5: error: unknown type name ‘uint32_t’; did you mean ‘u_int32_t’?
     uint32_t cdata[BCRYPT_WORDS];
     ^~~~~~~~
     u_int32_t
cli/bcrypt.h:118:24: error: ‘uint8_t’ undeclared (first use in this function); did you mean ‘u_int8_t’?
             key_len = (uint8_t)(strlen( key ) + 1);
                        ^~~~~~~
                        u_int8_t
cli/bcrypt.h:118:24: note: each undeclared identifier is reported only once for each function it appears in
cli/bcrypt.h:155:9: warning: implicit declaration of function ‘decode_base64’; did you mean ‘encode_base64’? [-Wimplicit-function-declaration]
     if (decode_base64( csalt, BCRYPT_MAXSALT, (char *)salt ))
         ^~~~~~~~~~~~~
         encode_base64
cli/bcrypt.h:162:23: error: expected expression before ‘)’ token
             (uint8_t *)key, (uint16_t)key_len );
                       ^
cli/bcrypt.h:161:35: warning: passing argument 2 of ‘Blowfish_expandstate’ from incompatible pointer type [-Wincompatible-pointer-types]
     Blowfish_expandstate( &state, csalt, salt_len,
                                   ^~~~~
In file included from cli/bcrypt.h:44:0,
                 from cli/mpw-bench.c:34:
cli/blowfish.h:454:1: note: expected ‘const u_int8_t * {aka const unsigned char *}’ but argument is of type ‘int *’
 Blowfish_expandstate(blf_ctx *c, const u_int8_t *data, u_int16_t databytes,
 ^~~~~~~~~~~~~~~~~~~~
In file included from cli/mpw-bench.c:34:0:
cli/bcrypt.h:161:5: error: too few arguments to function ‘Blowfish_expandstate’
     Blowfish_expandstate( &state, csalt, salt_len,
     ^~~~~~~~~~~~~~~~~~~~
In file included from cli/bcrypt.h:44:0,
                 from cli/mpw-bench.c:34:
cli/blowfish.h:454:1: note: declared here
 Blowfish_expandstate(blf_ctx *c, const u_int8_t *data, u_int16_t databytes,
 ^~~~~~~~~~~~~~~~~~~~
In file included from cli/mpw-bench.c:34:0:
cli/bcrypt.h:164:50: error: expected expression before ‘)’ token
         Blowfish_expand0state( &state, (uint8_t *)key, (uint16_t)key_len );
                                                  ^
cli/bcrypt.h:164:9: error: too few arguments to function ‘Blowfish_expand0state’
         Blowfish_expand0state( &state, (uint8_t *)key, (uint16_t)key_len );
         ^~~~~~~~~~~~~~~~~~~~~
In file included from cli/bcrypt.h:44:0,
                 from cli/mpw-bench.c:34:
cli/blowfish.h:416:1: note: declared here
 Blowfish_expand0state(blf_ctx *c, const u_int8_t *key, u_int16_t keybytes)
 ^~~~~~~~~~~~~~~~~~~~~
In file included from cli/mpw-bench.c:34:0:
cli/bcrypt.h:165:40: warning: passing argument 2 of ‘Blowfish_expand0state’ from incompatible pointer type [-Wincompatible-pointer-types]
         Blowfish_expand0state( &state, csalt, salt_len );
                                        ^~~~~
In file included from cli/bcrypt.h:44:0,
                 from cli/mpw-bench.c:34:
cli/blowfish.h:416:1: note: expected ‘const u_int8_t * {aka const unsigned char *}’ but argument is of type ‘int *’
 Blowfish_expand0state(blf_ctx *c, const u_int8_t *key, u_int16_t keybytes)
 ^~~~~~~~~~~~~~~~~~~~~
In file included from cli/mpw-bench.c:34:0:
cli/bcrypt.h:171:42: warning: passing argument 1 of ‘Blowfish_stream2word’ from incompatible pointer type [-Wincompatible-pointer-types]
         cdata[i] = Blowfish_stream2word( ciphertext, 4 * BCRYPT_WORDS, &j );
                                          ^~~~~~~~~~
In file included from cli/bcrypt.h:44:0,
                 from cli/mpw-bench.c:34:
cli/blowfish.h:395:1: note: expected ‘const u_int8_t * {aka const unsigned char *}’ but argument is of type ‘int *’
 Blowfish_stream2word(const u_int8_t *data, u_int16_t databytes,
 ^~~~~~~~~~~~~~~~~~~~
In file included from cli/mpw-bench.c:34:0:
cli/bcrypt.h:171:72: warning: passing argument 3 of ‘Blowfish_stream2word’ from incompatible pointer type [-Wincompatible-pointer-types]
         cdata[i] = Blowfish_stream2word( ciphertext, 4 * BCRYPT_WORDS, &j );
                                                                        ^
In file included from cli/bcrypt.h:44:0,
                 from cli/mpw-bench.c:34:
cli/blowfish.h:395:1: note: expected ‘u_int16_t * {aka short unsigned int *}’ but argument is of type ‘int *’
 Blowfish_stream2word(const u_int8_t *data, u_int16_t databytes,
 ^~~~~~~~~~~~~~~~~~~~
In file included from cli/mpw-bench.c:34:0:
cli/bcrypt.h: In function ‘bcrypt_newhash’:
cli/bcrypt.h:207:5: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
     uint8_t salt[BCRYPT_SALTSPACE];
     ^~~~~~~
     u_int8_t
cli/bcrypt.h:209:9: warning: implicit declaration of function ‘bcrypt_initsalt’; did you mean ‘bcrypt_newhash’? [-Wimplicit-function-declaration]
     if (bcrypt_initsalt( log_rounds, salt, sizeof( salt ) ) != 0)
         ^~~~~~~~~~~~~~~
         bcrypt_newhash
cli/bcrypt.h: In function ‘bcrypt_checkpass’:
cli/bcrypt.h:224:39: error: unknown type name ‘uint8_t’
     if (bcrypt_hashpass( pass, (const uint8_t *)goodhash, hash, sizeof( hash ) ) != 0)
                                       ^~~~~~~
cli/bcrypt.h: At top level:
cli/bcrypt.h:273:14: error: unknown type name ‘uint8_t’
 static const uint8_t Base64Code[] =
              ^~~~~~~
cli/bcrypt.h:274:9: error: wide character array initialized from non-wide string
         "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cli/bcrypt.h:276:14: error: unknown type name ‘uint8_t’
 static const uint8_t index_64[128] = {
              ^~~~~~~
cli/bcrypt.h:297:15: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
 decode_base64(uint8_t *buffer, size_t len, const char *b64data) {
               ^~~~~~~
               u_int8_t
cli/bcrypt.h:340:38: error: unknown type name ‘uint8_t’
 encode_base64(char *b64buffer, const uint8_t *data, size_t len) {
                                      ^~~~~~~
cli/bcrypt.h: In function ‘encode_base64’:
cli/bcrypt.h:342:5: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
     uint8_t *bp = (uint8_t *)b64buffer;
     ^~~~~~~
     u_int8_t
cli/bcrypt.h:342:20: error: ‘uint8_t’ undeclared (first use in this function); did you mean ‘u_int8_t’?
     uint8_t *bp = (uint8_t *)b64buffer;
                    ^~~~~~~
                    u_int8_t
cli/bcrypt.h:342:29: error: expected expression before ‘)’ token
     uint8_t *bp = (uint8_t *)b64buffer;
                             ^
cli/bcrypt.h:342:28: error: invalid operands to binary * (have ‘const int *’ and ‘const int *’)
     uint8_t *bp = (uint8_t *)b64buffer;
                    ~~~~~~~ ^
cli/bcrypt.h:342:19: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     uint8_t *bp = (uint8_t *)b64buffer;
                   ^
cli/bcrypt.h:343:19: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘*’ token
     const uint8_t *p = data;
                   ^
cli/bcrypt.h:343:20: error: ‘p’ undeclared (first use in this function); did you mean ‘bp’?
     const uint8_t *p = data;
                    ^
                    bp
cli/bcrypt.h:343:22: error: assignment of read-only location ‘*(const int *)&<erroneous-expression>’
     const uint8_t *p = data;
                      ^
cli/bcrypt.h:344:13: error: expected ‘;’ before ‘c1’
     uint8_t c1, c2;
             ^~
cli/bcrypt.h:347:9: error: ‘c1’ undeclared (first use in this function); did you mean ‘y1’?
         c1 = *p++;
         ^~
         y1
cli/bcrypt.h:347:16: error: lvalue required as increment operand
         c1 = *p++;
                ^~
cli/bcrypt.h:348:32: error: invalid operands to binary >> (have ‘const int *’ and ‘int’)
         *bp++ = Base64Code[(c1 >> 2)];
                             ~~ ^~
cli/bcrypt.h:348:27: error: array subscript is not an integer
         *bp++ = Base64Code[(c1 >> 2)];
                           ^
cli/bcrypt.h:348:15: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
         *bp++ = Base64Code[(c1 >> 2)];
               ^
cli/bcrypt.h:349:28: error: invalid operands to binary & (have ‘const int *’ and ‘int’)
         c1 = (uint8_t)((c1 & 0x03) << 4);
                         ~~ ^
cli/bcrypt.h:349:36: error: invalid operands to binary << (have ‘const int *’ and ‘int’)
         c1 = (uint8_t)((c1 & 0x03) << 4);
                        ~           ^~
cli/bcrypt.h:349:14: error: called object is not a function or function pointer
         c1 = (uint8_t)((c1 & 0x03) << 4);
              ^
cli/bcrypt.h:351:31: error: array subscript is not an integer
             *bp++ = Base64Code[c1];
                               ^
cli/bcrypt.h:351:19: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
             *bp++ = Base64Code[c1];
                   ^
cli/bcrypt.h:354:9: error: ‘c2’ undeclared (first use in this function); did you mean ‘c1’?
         c2 = *p++;
         ^~
         c1
cli/bcrypt.h:354:16: error: lvalue required as increment operand
         c2 = *p++;
                ^~
cli/bcrypt.h:355:19: error: invalid operands to binary >> (have ‘const int *’ and ‘int’)
         c1 |= (c2 >> 4) & 0x0f;
                ~~ ^~
cli/bcrypt.h:355:25: error: invalid operands to binary & (have ‘const int *’ and ‘int’)
         c1 |= (c2 >> 4) & 0x0f;
               ~         ^
cli/bcrypt.h:356:27: error: array subscript is not an integer
         *bp++ = Base64Code[c1];
                           ^
cli/bcrypt.h:356:15: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
         *bp++ = Base64Code[c1];
               ^
cli/bcrypt.h:357:28: error: invalid operands to binary & (have ‘const int *’ and ‘int’)
         c1 = (uint8_t)((c2 & 0x0f) << 2);
                         ~~ ^
cli/bcrypt.h:357:36: error: invalid operands to binary << (have ‘const int *’ and ‘int’)
         c1 = (uint8_t)((c2 & 0x0f) << 2);
                        ~           ^~
cli/bcrypt.h:357:14: error: called object is not a function or function pointer
         c1 = (uint8_t)((c2 & 0x0f) << 2);
              ^
cli/bcrypt.h:359:31: error: array subscript is not an integer
             *bp++ = Base64Code[c1];
                               ^
cli/bcrypt.h:359:19: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
             *bp++ = Base64Code[c1];
                   ^
cli/bcrypt.h:362:16: error: lvalue required as increment operand
         c2 = *p++;
                ^~
cli/bcrypt.h:363:19: error: invalid operands to binary >> (have ‘const int *’ and ‘int’)
         c1 |= (c2 >> 6) & 0x03;
                ~~ ^~
cli/bcrypt.h:363:25: error: invalid operands to binary & (have ‘const int *’ and ‘int’)
         c1 |= (c2 >> 6) & 0x03;
               ~         ^
cli/bcrypt.h:364:27: error: array subscript is not an integer
         *bp++ = Base64Code[c1];
                           ^
cli/bcrypt.h:364:15: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
         *bp++ = Base64Code[c1];
               ^
cli/bcrypt.h:365:31: error: invalid operands to binary & (have ‘const int *’ and ‘int’)
         *bp++ = Base64Code[c2 & 0x3f];
                            ~~ ^
cli/bcrypt.h:365:27: error: array subscript is not an integer
         *bp++ = Base64Code[c2 & 0x3f];
                           ^
cli/bcrypt.h:365:15: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
         *bp++ = Base64Code[c2 & 0x3f];
               ^
cli/bcrypt.h: At top level:
cli/bcrypt.h:374:8: error: unknown type name ‘uint8_t’
 static uint8_t *
        ^~~~~~~
cli/bcrypt.h:375:16: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
 bcrypt_gensalt(uint8_t log_rounds) {
                ^~~~~~~
                u_int8_t
cli/bcrypt.h:385:32: error: unknown type name ‘uint8_t’
 bcrypt(const char *pass, const uint8_t *salt) {
                                ^~~~~~~
cli/mpw-bench.c: In function ‘main’:
cli/mpw-bench.c:104:33: warning: implicit declaration of function ‘bcrypt_gensalt’; did you mean ‘bcrypt_newhash’? [-Wimplicit-function-declaration]
         bcrypt( masterPassword, bcrypt_gensalt( bcrypt_rounds ) );
                                 ^~~~~~~~~~~~~~
                                 bcrypt_newhash
cli/mpw-bench.c:104:33: warning: passing argument 2 of ‘bcrypt’ makes pointer from integer without a cast [-Wint-conversion]
In file included from cli/mpw-bench.c:34:0:
cli/bcrypt.h:385:1: note: expected ‘const int *’ but argument is of type ‘int’
 bcrypt(const char *pass, const uint8_t *salt) {
 ^~~~~~```