### PR TITLE
Include Name and Phrase password types in algorithm documentation.

### DIFF
--- a/public/site/2013-05/algorithm.html
+++ b/public/site/2013-05/algorithm.html
@@ -215,6 +215,18 @@ passWord[i] = passChar</pre>
                                 <li><code>nnnn</code></li>
                             </ul>
                         </p></li>
+                        <li><p>Type: <strong>Name</strong>
+                            <ul>
+                                <li><code>cvccvcvcv</code></li>
+                            </ul>
+                        </p></li>
+                        <li><p>Type: <strong>Phrase</strong>
+                            <ul>
+                                <li><code>cvcc cvc cvccvcv cvc</code></li>
+                                <li><code>cvc cvccvcvcv cvcv</code></li>
+                                <li><code>cv cvccv cvc cvcvccv</code></li>
+                            </ul>
+                        </p></li>
                     </ul>
                 </p>
                 <p>


### PR DESCRIPTION
I noticed that the name and phrase password types were not included in the algorithm documentation. There are a couple of third party mpw tools that do not include these password types, and I think it might be because they're not listed on the page.