### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "External/Pearl"]
 	path = platform-darwin/External/Pearl
-	url = git://github.com/Lyndir/Pearl.git
+	url = https://github.com/Lyndir/Pearl.git
 [submodule "External/AttributedMarkdown"]
 	path = platform-darwin/External/AttributedMarkdown
 	url = https://github.com/dreamwieber/AttributedMarkdown.git


### PR DESCRIPTION
The protocol is changed to https for a submodule. Otherwise it's not possible to clone a repo, in Dockerfile in particular.